### PR TITLE
Don't print a line for every consumed message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -307,16 +307,16 @@ impl ConsumeCounter {
     }
 
     pub fn record_borrowed_message_receipt(&mut self, msg: &BorrowedMessage<'_>) -> bool {
-        // log every 10000 messages
-        if msg.offset() % 10000 == 0 {
-            debug!("Message received: {}", msg.offset());
-        }
         self.count += 1;
         let c = match self.target_count {
             Some(i) => i,
             None => 0,
         };
-        info!("Count {}/{}", self.count, c);
+        // log every 10000 messages
+        if msg.offset() % 10000 == 0 {
+            debug!("Message received: {}", msg.offset());
+            info!("Count {}/{}", self.count, c);
+        }
         match self.target_count {
             None => false,
             Some(limit) => self.count >= limit,


### PR DESCRIPTION
This gets quite nice and we already have a filter for debug level messages but the info message we still log for every message.

Move the info message into the check to only print every 10k messages.