### PR TITLE
Pace producer/consumer spawn

### DIFF
--- a/src/consumers.rs
+++ b/src/consumers.rs
@@ -5,6 +5,7 @@ use rdkafka::message::BorrowedMessage;
 use rdkafka::Message;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 use tokio;
@@ -196,6 +197,7 @@ pub async fn consumers(
     messages: Option<u64>,
     properties: Vec<String>,
     metrics: metrics::MetricsContext,
+    client_spawn_wait: Duration,
 ) {
     let kv_pairs = split_properties(properties);
     let mut tasks = vec![];
@@ -229,7 +231,9 @@ pub async fn consumers(
             counter.clone(),
             metrics.spawn_new_sender(),
             cancel.clone(),
-        )))
+        )));
+
+        tokio::time::sleep(client_spawn_wait).await;
     }
 
     for t in tasks {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use clap::{Parser, Subcommand};
 
+use rdkafka::client;
 use tokio;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -77,6 +78,8 @@ enum Commands {
         compressible_payload: bool,
         #[clap(long, default_value_t = 1000)]
         keys: u64,
+        #[clap(long, default_value_t = 33)]
+        client_spawn_wait_ms: u64,
     },
     /// Creates consumer swarm
     Consumers {
@@ -99,6 +102,8 @@ enum Commands {
         properties: Vec<String>,
         #[clap(short, long)]
         messages: Option<u64>,
+        #[clap(long, default_value_t = 33)]
+        client_spawn_wait_ms: u64,
     },
 }
 
@@ -175,6 +180,7 @@ async fn main() {
             max_record_size,
             keys,
             timeout_ms,
+            client_spawn_wait_ms,
         }) => {
             let min_size = min_record_size.unwrap_or(*max_record_size);
             if let Some(min) = min_record_size {
@@ -204,6 +210,7 @@ async fn main() {
                 },
                 Duration::from_millis(*timeout_ms),
                 mc,
+                Duration::from_millis(*client_spawn_wait_ms)
             )
             .await;
         }
@@ -216,6 +223,7 @@ async fn main() {
             count,
             properties,
             messages,
+            client_spawn_wait_ms,
         }) => {
             consumers(
                 brokers,
@@ -228,6 +236,7 @@ async fn main() {
                 *messages,
                 properties.clone(),
                 mc,
+                Duration::from_millis(*client_spawn_wait_ms),
             )
             .await;
         }

--- a/src/producers.rs
+++ b/src/producers.rs
@@ -175,6 +175,7 @@ pub async fn producers(
     payload: Payload,
     timeout: Duration,
     metrics: MetricsContext,
+    client_spawn_wait: Duration,
 ) {
     let mut tasks = vec![];
     let kv_pairs = split_properties(properties);
@@ -208,7 +209,9 @@ pub async fn producers(
             payload.clone(),
             timeout,
             metrics.spawn_new_sender(),
-        )))
+        )));
+
+        tokio::time::sleep(client_spawn_wait).await;
     }
 
     let mut results = vec![];


### PR DESCRIPTION
Pace the creation of producers and consumers to allow each client to
fully complete the connection setup and not overload the the client
machines with thousands of threads trying to get scheduled at the same
time.

Add a CLI to allow overriding the default behaviour.