### PR TITLE
producers: add message period flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "governor",
  "histogram",
  "http-body-util",
+ "humantime",
  "hyper",
  "hyper-util",
  "lazy_static",
@@ -871,9 +872,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ form_urlencoded = "1.2.1"
 bytes = "1.5.0"
 http-body-util = "0.1.0"
 shadow-rs = "0.27.1"
+humantime = "2.2.0"
 
 [build-dependencies]
 shadow-rs = "0.27.1"


### PR DESCRIPTION
This flag allows one to specify message rates that are less than 1 msg/s which isn't possible with the messages per second flag. I.e, allows one to specify 1 message every 2 seconds. 