### PR TITLE
wrapper: also override cgroup pids.max for k8s pods

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -5,9 +5,20 @@
 
 set -e
 
+# override pids.max cgroup values if running in Kubernetes pod
+CGROUP=$(cut -c4- < /proc/self/cgroup)
+[[ -f /run/secrets/kubernetes.io/serviceaccount/namespace ]] && while [[ "/" != "${CGROUP}" ]]; do
+        [[ $(<"/sys/fs/cgroup/${CGROUP}/pids.max") != "max" ]] && echo "max" > "/sys/fs/cgroup/${CGROUP}/pids.max"
+        CGROUP=$(dirname ${CGROUP})
+done
+
+# set relevant sysctl values
 echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
 echo 15000 64000 > /proc/sys/net/ipv4/ip_local_port_range
 echo 1000000 > /proc/sys/vm/max_map_count
+echo 1000000 > /proc/sys/kernel/threads-max
+
+# set relevant ulimit values
 ulimit -n 1000000
 ulimit -s 200000
 ulimit -i unlimited


### PR DESCRIPTION
The pids.max cgroup limit was preventing us from scaling the number of consumers and producers up when running client-swarm in kubernetes pods. With these additional overrides, I was able to successfully complete a test with 20 instances of client-swarm with consumer count=2000 and 20 instances with producer count=1200 running on m7a.2xlarge EC2 instances.